### PR TITLE
Added basic node server with example endpoints.

### DIFF
--- a/server/.eslintrc.json
+++ b/server/.eslintrc.json
@@ -1,0 +1,293 @@
+{
+  "env": {
+    "browser": true,
+    "es6": true,
+    "node": true
+  },
+  "extends": [
+    "eslint:recommended"
+  ],
+  "globals": {
+    "Atomics": "readonly",
+    "SharedArrayBuffer": "readonly"
+  },
+  "parserOptions": {
+    "ecmaFeatures": {
+      "jsx": true
+    },
+    "ecmaVersion": 2018,
+    "sourceType": "module"
+  },
+  "rules": {
+    "indent": [
+      "error",
+      2
+    ],
+    "no-extra-parens": [
+      "error",
+      "all"
+    ],
+    "no-await-in-loop": "error",
+    "no-dupe-else-if": "error",
+    "no-import-assign": "error",
+    "no-setter-return": "error",
+    "no-template-curly-in-string": "error",
+    "require-atomic-updates": "error",
+    "accessor-pairs": "error",
+    "array-callback-return": "error",
+    "complexity": [
+      "error",
+      20
+    ],
+    "jsx-quotes": [
+      "error",
+      "prefer-double"
+    ],
+    "key-spacing": [
+      "error",
+      {
+        "beforeColon": false,
+        "afterColon": true
+      }
+    ],
+    "keyword-spacing": [
+      "error",
+      {
+        "before": true,
+        "after": true
+      }
+    ],
+    "consistent-return": "error",
+    "no-lone-blocks": "error",
+    "curly": "error",
+    "default-case": "error",
+    "default-param-last": "error",
+    "dot-location": [
+      "error",
+      "property"
+    ],
+    "dot-notation": "error",
+    "eqeqeq": "error",
+    "guard-for-in": "error",
+    "no-alert": "error",
+    "no-caller": "error",
+    "no-constructor-return": "error",
+    "no-div-regex": "error",
+    "no-else-return": "error",
+    "no-empty-function": "error",
+    "no-eq-null": "error",
+    "no-eval": "error",
+    "no-extend-native": "error",
+    "no-extra-bind": "error",
+    "no-extra-label": "error",
+    "no-floating-decimal": "error",
+    "no-implicit-coercion": "error",
+    "no-implied-eval": "error",
+    "no-invalid-this": "error",
+    "no-iterator": "error",
+    "no-labels": "error",
+    "no-loop-func": "error",
+    "no-magic-numbers": "error",
+    "no-multi-spaces": "error",
+    "no-multi-str": "error",
+    "no-new": "error",
+    "no-new-func": "error",
+    "no-new-wrappers": "error",
+    "no-octal-escape": "error",
+    "no-param-reassign": "error",
+    "no-proto": "error",
+    "no-return-assign": "error",
+    "no-return-await": "error",
+    "no-script-url": "error",
+    "no-self-compare": "error",
+    "no-sequences": "error",
+    "no-throw-literal": "error",
+    "no-unmodified-loop-condition": "error",
+    "no-unused-expressions": "error",
+    "no-useless-call": "error",
+    "no-useless-concat": "error",
+    "no-useless-return": "error",
+    "no-void": "error",
+    "no-warning-comments": "error",
+    "no-shadow": "error",
+    "no-undef-init": "error",
+    "no-undefined": "error",
+    "no-use-before-define": "error",
+    "callback-return": "error",
+    "global-require": "error",
+    "no-buffer-constructor": "error",
+    "no-mixed-requires": "error",
+    "no-new-require": "error",
+    "no-path-concat": "error",
+    "no-process-env": "error",
+    "no-process-exit": "error",
+    "array-bracket-newline": [
+      "error",
+      {
+        "multiline": true
+      }
+    ],
+    "block-spacing": "error",
+    "array-element-newline": [
+      "error",
+      {
+        "multiline": true
+      }
+    ],
+    "array-bracket-spacing": [
+      "error",
+      "never"
+    ],
+    "brace-style": [
+      "error",
+      "1tbs"
+    ],
+    "capitalized-comments": [
+      "error",
+      "never"
+    ],
+    "comma-dangle": [
+      "off",
+      {
+        "arrays": "always",
+        "objects": "always"
+      }
+    ],
+    "comma-spacing": [
+      "error",
+      {
+        "before": false,
+        "after": true
+      }
+    ],
+    "camelcase": "error",
+    "prefer-promise-reject-errors": "error",
+    "prefer-regex-literals": "error",
+    "radix": "error",
+    "max-classes-per-file": [
+      "error",
+      1
+    ],
+    "function-paren-newline": [
+      "error",
+      "never"
+    ],
+    "lines-between-class-members": "error",
+    "implicit-arrow-linebreak": [
+      "error",
+      "beside"
+    ],
+    "max-len": [
+      "error",
+      {
+        "tabWidth": 2,
+        "code": 1000
+      }
+    ],
+    "multiline-ternary": [
+      "error",
+      "never"
+    ],
+    "no-bitwise": "error",
+    "no-continue": "error",
+    "no-lonely-if": "error",
+    "no-mixed-operators": "error",
+    "no-multi-assign": "error",
+    "quotes": [
+      "error",
+      "double"
+    ],
+    "space-before-function-paren": [
+      "error",
+      "never"
+    ],
+    "spaced-comment": [
+      "error",
+      "never"
+    ],
+    "switch-colon-spacing": [
+      "error",
+      {
+        "after": true,
+        "before": false
+      }
+    ],
+    "space-infix-ops": "error",
+    "space-in-parens": "error",
+    "semi-spacing": [
+      "error",
+      {
+        "before": false,
+        "after": true
+      }
+    ],
+    "semi-style": [
+      "error",
+      "last"
+    ],
+    "no-multiple-empty-lines": [
+      "error",
+      {
+        "max": 3
+      }
+    ],
+    "semi": "error",
+    "prefer-exponentiation-operator": "error",
+    "object-property-newline": [
+      "error",
+      {
+        "allowAllPropertiesOnSameLine": true
+      }
+    ],
+    "operator-assignment": [
+      "error",
+      "always"
+    ],
+    "padded-blocks": [
+      "error",
+      "never"
+    ],
+    "no-underscore-dangle": "error",
+    "no-whitespace-before-property": "error",
+    "no-nested-ternary": "error",
+    "no-new-object": "error",
+    "no-trailing-spaces": "error",
+    "newline-per-chained-call": [
+      "error",
+      {
+        "ignoreChainWithDepth": 3
+      }
+    ],
+    "no-array-constructor": "error",
+    "max-statements-per-line": [
+      "error",
+      {
+        "max": 1
+      }
+    ],
+    "function-call-argument-newline": [
+      "off",
+      "never"
+    ],
+    "arrow-body-style": [
+      "error",
+      "always"
+    ],
+    "arrow-parens": "error",
+    "arrow-spacing": [
+      "error",
+      {
+        "before": true,
+        "after": true
+      }
+    ],
+    "func-call-spacing": "error",
+    "eol-last": "error",
+    "grouped-accessor-pairs": "error",
+    "linebreak-style": [
+      "error",
+      "unix"
+    ]
+  }
+}
+

--- a/server/app.js
+++ b/server/app.js
@@ -1,0 +1,47 @@
+const express = require("express");
+//const csvToJson = require("csvtojson");
+const { Parser } = require("json2csv");
+
+var app = express();
+const portNumber = 8080;
+
+//this is an example of an endpoint. When the user requests the root page of the server,
+//like "http://localhost", the server replies by sending a response of "Hello World".
+app.get("/", function(req, response) {
+  response.send("Hello world");
+});
+
+//this is another endpoint. When someone requests "http://localhost/sample.csv", the server
+//responds with this little csv file.q
+app.get("/sample.csv", function(req, res) {
+  var jsonRows = [
+    {
+      "firstName": "Warren",
+      "lastName": "Harrison",
+      "workplace": "PSU",
+    },
+    {
+      "firstName": "John",
+      "lastName": "Schroeder",
+      "workplace": "Amazon",
+    },
+    {
+      "firstName": "Shannon",
+      "lastName": "Gee",
+      "workplace": "Ecdysiast",
+    },
+  ];
+
+  var fields = ["firstName", "lastName", "workplace"];
+  var parser = new Parser({fields});
+  var csv = parser.parse(jsonRows);
+  res.contentType("text/csv");
+  res.send(csv);
+});
+
+
+//start up the server, now that the endpoint handlers are installed.
+app.listen(portNumber, function() {
+  console.log("Mindboy server listening at http://localhost:%s", portNumber);
+});
+

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "mindbody-report-server",
+  "version": "1.0.0",
+  "description": "Generates reports using data from MindBody",
+  "main": "app.js",
+  "dependencies": {
+    "csvtojson": "^2.0.10",
+    "express": "^4.17.1",
+    "json2csv": "^4.5.4"
+  },
+  "devDependencies": {
+    "eslint": "^6.8.0",
+    "eslint-config-standard": "^14.1.0",
+    "eslint-plugin-import": "^2.20.1",
+    "eslint-plugin-node": "^11.0.0",
+    "eslint-plugin-promise": "^4.2.1",
+    "eslint-plugin-standard": "^4.0.1"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/yeatonl/mindbody-report-generation.git"
+  },
+  "keywords": [
+    "mindbody"
+  ],
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/yeatonl/mindbody-report-generation/issues"
+  },
+  "homepage": "https://github.com/yeatonl/mindbody-report-generation#readme"
+}


### PR DESCRIPTION
Addresses the Trello card named "Create basic NodeJS app.js file". Approved by Floris.

 - Note that we used javascript's require instead of Raven's recommendation of import.
   Import was rejected by eslint and failed to load the file in NodeJS for Daniel.
 - I made small changes to the .eslintrc.json from .../client/.eslintrc.json that you can see in a diff. We should revisit these:
   - Removed references to react from file because they are (probably) not needed in the server.
   - Changed comma-dangle setting from error to off. In vscode, Daniel found no way
     to define an array of strings because of interactions between comma-dangle and
     comma-spacing... everything was rejected :(