### PR TITLE
Changed server to use ES6 export/import

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -1,7 +1,7 @@
-const express = require("express");
-//const csvToJson = require("csvtojson");
-const { Parser } = require("json2csv");
-const commissionRpt = require("./reports/commission/commission-report.js");
+import express from "express";
+import json2csvExports from "json2csv";
+import {handleCommissionRptRequest} from "./reports/commission/commission-report.js";
+
 
 var app = express();
 const portNumber = 8080;
@@ -36,14 +36,14 @@ app.get("/sample.csv", function(req, res) {
   ];
 
   var fields = ["firstName", "lastName", "workplace"];
-  var parser = new Parser({fields});
+  var parser = new json2csvExports.Parser({fields});
   var csv = parser.parse(jsonRows);
   res.contentType("text/csv");
   res.send(csv);
 });
 
 
-app.get("/reports/commission", commissionRpt.handleExpressRequest);
+app.get("/reports/commission", handleCommissionRptRequest);
 
 
 //start up the server, now that the endpoint handlers are installed.

--- a/server/package.json
+++ b/server/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "Generates reports using data from MindBody",
   "main": "app.js",
+  "type": "module",
   "dependencies": {
     "csvtojson": "^2.0.10",
     "express": "^4.17.1",

--- a/server/reports/commission/commission-report.js
+++ b/server/reports/commission/commission-report.js
@@ -1,11 +1,11 @@
 // module "commission-report"
-const { Parser } = require("json2csv");
+import json2csvExports from "json2csv";
 
 
 /* A handy request URLS for testing:
 http://localhost:8080/reports/commission?format=csv&startdate=111&enddate=2222
 */
-function handleExpressRequest(request, response) {
+export function handleCommissionRptRequest(request, response) {
 
   //console.log("handleExpressRequest:");
   //console.log("request: " + request.baseUrl + " - " + JSON.stringify(request.query));
@@ -61,7 +61,7 @@ function handleExpressRequest(request, response) {
   // Generate output
   if (format === "csv") {
     let fields = ["paramName", "value"];
-    let parser = new Parser({fields});
+    let parser = new json2csvExports.Parser({fields});
     let csv = parser.parse(rptJsonRowsAsJson);
     let fileName = "CommissionReport.csv";
     //TODO: As a user, I'd appreciate a more unique filename with the date range embedded
@@ -72,7 +72,4 @@ function handleExpressRequest(request, response) {
     response.json(rptJsonRowsAsJson);
   }
 }
-
-
-module.exports = {handleExpressRequest};
 


### PR DESCRIPTION
This replaces the older require() syntax. This is working for me, Daniel. let's make sure it works for others, especially Jason who is actually using ES6 modules somewhere.
This includes an example of exporting a function, handleCommissionRptRequest, from our commission-report.js and importing it in app.js

I have one complaint about this change: Now, whenever we launch the server, it gives us an ugly message like: 
`(node:9251) ExperimentalWarning: The ESM module loader is experimental.`
It's a little distracting, but I don't think we can safely suppress just this one warning.