### PR TITLE
Add caching to MindbodyAccess GET requests

### DIFF
--- a/server/api-manager.js
+++ b/server/api-manager.js
@@ -942,19 +942,21 @@ class MindbodyQueries {
     this.requestNum++;
     if (!this.atLimit()) {
       let reqPromise = request.makeRequest();
-      reqPromise.then((result) => {
+      if (request.verb === "GET") {
         //store results in the cache before the caller gets access to them.
-        let hashCode = this.getStringHash(request.siteId.toString + request.url);
-        let cacheTuple = {
-          siteId: request.siteId,
-          url: request.url,
-          creationTime: Date.now(),
-          result: result,
-        };
-        this.cachedResults[hashCode] = cacheTuple;
-        //console.log("MindbodyAccess stored this cacheTuple " +
-        //,  JSON.stringify(cacheTuple) + " at hash value: " + hashCode);
-      });
+        reqPromise.then((result) => {
+          let hashCode = this.getStringHash(request.siteId.toString + request.url);
+          let cacheTuple = {
+            siteId: request.siteId,
+            url: request.url,
+            creationTime: Date.now(),
+            result: result,
+          };
+          this.cachedResults[hashCode] = cacheTuple;
+          //console.log("MindbodyAccess stored this cacheTuple " +
+          //,  JSON.stringify(cacheTuple) + " at hash value: " + hashCode);
+        });
+      }
       return reqPromise;
     }
     return Promise.reject(Error("Request limit reached"));


### PR DESCRIPTION
This adds a simple caching layer. It works for me on both reports. You can get log messages seeing it an action if you uncomment them. Otherwise, the only difference you'll see is that requesting the same report twice runs very very quickly now.

I added inline comments below about it all.

One thibg in the Trello ticket said "Caching should not ignore pagination". I believe that this is currently covered, tho it's not very visible. The parameters we'll send for pagination are just more  params to the MB REST api, like .../appointments/activesessiontimes?offset=100&limit=100. Because those parameters are included in the querystring and that querystring is the key for where we store cached results, pagination probably works OK with this caching. Like if you asked for GetClients page 1, then page 2, then asked again for page 1 and page 2, those results would be cached... both requests for GetClient page 2 would have identical querystrings and therefore the same cache entry.