### PR TITLE
Fix possible bug in generating CSV output

### DIFF
--- a/server/reports/attendance/attendance-endpoint.js
+++ b/server/reports/attendance/attendance-endpoint.js
@@ -101,9 +101,15 @@ export function attendanceRequestHandler(request, response) {
       Promise.all(allNumberAttendedPromises)
         .then(() => {
           if (format === "csv") {
-            let fields = ["classId", "classTitle", "classStartTime", "capacity", "registered", "attended"];
-            let parser = new J2C.Parser({ fields });
-            let csv = parser.parse(attendanceReport);
+            let parser = new J2C.Parser(attendanceReport.headers);
+            let dataForParser = attendanceReport.data.map((row) => {
+              let rowForParser = {};
+              for (let i = 0; i < attendanceReport.headers.length; i ++) {
+                rowForParser[attendanceReport.headers[i]] = row[i];
+              }
+              return rowForParser;
+            });
+            let csv = parser.parse(dataForParser);
             let fileName = "AttendanceReport.csv";
             //todo: we should choose a filename that includes helpful info like the date range
             response.setHeader("Content-Disposition", "attachment ; filename=\"" + fileName + "\"");


### PR DESCRIPTION
For me, the CSV output is always just blank. The json2csv.parse function expects a different format from what we're supplying. It's supposed to look like the commission report. I added this code to generate the data format that it expects... so this is one possible fix.

Is csv working for you? I think that this changed/ broke when Raven did that architecture change/integration stuff, and now this part doesn't connect like it used to. I probably should have dug through old revisions in Git to track down what changed.